### PR TITLE
chore: pin GitHub Actions to SHA and enforce pinning policy

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,6 @@
+language: en-US
+reviews:
+  path_instructions:
+    - path: ".github/workflows/**"
+      instructions: |
+        All GitHub Actions must be pinned to full commit SHAs for supply chain security. Flag any action reference using a tag (e.g. @v4) or branch instead of a commit SHA. The only exception is references to gambit-security/shared-workflows, which may use branch/tag references.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code when working with code in this repository.
+
+## GitHub Actions Security
+
+All GitHub Actions in workflows **must be pinned to full commit SHAs** (not tags or branches) for supply chain security. The only exception is actions from `gambit-security/shared-workflows`, which may use branch/tag references.
+
+```yaml
+# WRONG - using tag
+- uses: actions/checkout@v4
+
+# CORRECT - pinned to SHA
+- uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+# CORRECT - shared-workflows exception (no SHA needed)
+- uses: gambit-security/shared-workflows/.github/workflows/build.yml@main
+```
+
+Use `pinact` to pin actions: `pinact run --exclude "gambit-security/shared-workflows"`


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions to full commit SHAs for supply chain security
- Add Dependabot configuration to keep GitHub Actions updated weekly
- Add `CLAUDE.md` rule requiring SHA-pinned actions (except `shared-workflows`)
- Add CodeRabbit review instruction to flag unpinned actions in PRs
- Exclude `gambit-security/shared-workflows` from pinning and automated updates

## Why
Using pinned SHAs prevents supply chain attacks where a compromised action tag could inject malicious code. Dependabot ensures we stay up-to-date with security patches. The CLAUDE.md and CodeRabbit rules enforce this going forward.

## Changes
- `.github/workflows/*.yml` — actions pinned to SHAs via `pinact`
- `.github/dependabot.yml` — added/updated with `github-actions` ecosystem
- `CLAUDE.md` — added GitHub Actions Security section
- `.coderabbit.yaml` — added path instruction for workflow files

🤖 Generated with [Claude Code](https://claude.com/claude-code)